### PR TITLE
Add spinner progress indicator

### DIFF
--- a/import.go
+++ b/import.go
@@ -221,7 +221,7 @@ func processFile(cfg importConfig, fi os.FileInfo, timestamp time.Time, logf fun
 	return nil
 }
 
-func runImport(cfg importConfig, out io.Writer) (importSummary, error) {
+func runImport(cfg importConfig, out, progress io.Writer) (importSummary, error) {
 	files, err := os.ReadDir(cfg.From)
 	if err != nil {
 		return importSummary{}, err
@@ -300,7 +300,7 @@ func runImport(cfg importConfig, out io.Writer) (importSummary, error) {
 	total = len(infos)
 	progressDone := make(chan struct{})
 	var progressWg sync.WaitGroup
-	if total > 0 {
+	if total > 0 && progress != nil {
 		progressWg.Add(1)
 		go func() {
 			defer progressWg.Done()
@@ -346,7 +346,7 @@ func runImport(cfg importConfig, out io.Writer) (importSummary, error) {
 					if name != "" {
 						line += " " + truncate(name, 48)
 					}
-					fmt.Fprint(os.Stderr, line)
+					fmt.Fprint(progress, line)
 					frameIdx++
 				case <-progressDone:
 					mu.Lock()
@@ -357,7 +357,7 @@ func runImport(cfg importConfig, out io.Writer) (importSummary, error) {
 					t := total
 					mu.Unlock()
 					fmt.Fprintf(
-						os.Stderr,
+						progress,
 						"\rDone checking %d/%d (copied %d, skipped %d, failed %d)\n",
 						p,
 						t,
@@ -400,7 +400,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(2)
 	}
-	if _, err := runImport(cfg, os.Stdout); err != nil {
+	if _, err := runImport(cfg, os.Stdout, os.Stderr); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}

--- a/import.go
+++ b/import.go
@@ -238,6 +238,8 @@ func runImport(cfg importConfig, out, progress io.Writer) (importSummary, error)
 	logf := func(format string, args ...any) {
 		mu.Lock()
 		defer mu.Unlock()
+		// Clear the current spinner line so the log prints on a clean line
+		fmt.Fprint(os.Stderr, "\r\033[2K")
 		fmt.Fprintf(out, format+"\n", args...)
 	}
 
@@ -335,7 +337,7 @@ func runImport(cfg importConfig, out, progress io.Writer) (importSummary, error)
 						p = t
 					}
 					line := fmt.Sprintf(
-						"\r%c Checking %d/%d (copied %d, skipped %d, failed %d)",
+						"\r\033[2K%c Checking %d/%d (copied %d, skipped %d, failed %d)",
 						frames[frameIdx%len(frames)],
 						p,
 						t,
@@ -358,7 +360,7 @@ func runImport(cfg importConfig, out, progress io.Writer) (importSummary, error)
 					mu.Unlock()
 					fmt.Fprintf(
 						progress,
-						"\rDone checking %d/%d (copied %d, skipped %d, failed %d)\n",
+						"\r\033[2KDone checking %d/%d (copied %d, skipped %d, failed %d)\n",
 						p,
 						t,
 						c,

--- a/import.go
+++ b/import.go
@@ -232,6 +232,8 @@ func runImport(cfg importConfig, out io.Writer) (importSummary, error) {
 	var (
 		mu      sync.Mutex
 		summary importSummary
+		current string
+		total   int
 	)
 	logf := func(format string, args ...any) {
 		mu.Lock()
@@ -248,6 +250,7 @@ func runImport(cfg importConfig, out io.Writer) (importSummary, error) {
 			for fi := range jobs {
 				mu.Lock()
 				summary.processed++
+				current = fi.Name()
 				mu.Unlock()
 
 				timestamp := resolveTimestamp(filepath.Join(cfg.From, fi.Name()), fi, logf)
@@ -274,6 +277,7 @@ func runImport(cfg importConfig, out io.Writer) (importSummary, error) {
 		}()
 	}
 
+	var infos []os.FileInfo
 	for _, f := range files {
 		if f.IsDir() {
 			continue
@@ -290,10 +294,90 @@ func runImport(cfg importConfig, out io.Writer) (importSummary, error) {
 			mu.Unlock()
 			continue
 		}
+		infos = append(infos, info)
+	}
+
+	total = len(infos)
+	progressDone := make(chan struct{})
+	var progressWg sync.WaitGroup
+	if total > 0 {
+		progressWg.Add(1)
+		go func() {
+			defer progressWg.Done()
+			frames := []byte{'|', '/', '-', '\\'}
+			frameIdx := 0
+			ticker := time.NewTicker(200 * time.Millisecond)
+			defer ticker.Stop()
+
+			truncate := func(s string, max int) string {
+				if len(s) <= max {
+					return s
+				}
+				if max <= 3 {
+					return s[:max]
+				}
+				return "..." + s[len(s)-(max-3):]
+			}
+
+			for {
+				select {
+				case <-ticker.C:
+					mu.Lock()
+					p := summary.processed
+					c := summary.copied
+					s := summary.skipped
+					f := summary.failed
+					name := current
+					t := total
+					mu.Unlock()
+
+					if p > t {
+						p = t
+					}
+					line := fmt.Sprintf(
+						"\r%c Checking %d/%d (copied %d, skipped %d, failed %d)",
+						frames[frameIdx%len(frames)],
+						p,
+						t,
+						c,
+						s,
+						f,
+					)
+					if name != "" {
+						line += " " + truncate(name, 48)
+					}
+					fmt.Fprint(os.Stderr, line)
+					frameIdx++
+				case <-progressDone:
+					mu.Lock()
+					p := summary.processed
+					c := summary.copied
+					s := summary.skipped
+					f := summary.failed
+					t := total
+					mu.Unlock()
+					fmt.Fprintf(
+						os.Stderr,
+						"\rDone checking %d/%d (copied %d, skipped %d, failed %d)\n",
+						p,
+						t,
+						c,
+						s,
+						f,
+					)
+					return
+				}
+			}
+		}()
+	}
+
+	for _, info := range infos {
 		jobs <- info
 	}
 	close(jobs)
 	wg.Wait()
+	close(progressDone)
+	progressWg.Wait()
 
 	fmt.Fprintf(
 		out,

--- a/import.go
+++ b/import.go
@@ -239,7 +239,9 @@ func runImport(cfg importConfig, out, progress io.Writer) (importSummary, error)
 		mu.Lock()
 		defer mu.Unlock()
 		// Clear the current spinner line so the log prints on a clean line
-		fmt.Fprint(os.Stderr, "\r\033[2K")
+		if progress != nil {
+			fmt.Fprint(progress, "\r\033[2K")
+		}
 		fmt.Fprintf(out, format+"\n", args...)
 	}
 

--- a/import_integration_test.go
+++ b/import_integration_test.go
@@ -65,7 +65,7 @@ func TestRunImportAppliesFilterAndDateRange(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	summary, err := runImport(cfg, &out)
+	summary, err := runImport(cfg, &out, nil)
 	if err != nil {
 		t.Fatalf("runImport returned error: %v\noutput:\n%s", err, out.String())
 	}
@@ -124,7 +124,7 @@ func TestRunImportNormalizesExtensionFolderName(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	summary, err := runImport(cfg, &out)
+	summary, err := runImport(cfg, &out, nil)
 	if err != nil {
 		t.Fatalf("runImport returned error: %v\noutput:\n%s", err, out.String())
 	}
@@ -147,8 +147,49 @@ func TestRunImportReturnsErrorForMissingSourceDir(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	_, err := runImport(cfg, &out)
+	_, err := runImport(cfg, &out, nil)
 	if err == nil {
 		t.Fatal("expected error for missing source directory")
+	}
+}
+
+func TestRunImportWritesProgressToDedicatedWriter(t *testing.T) {
+	root := t.TempDir()
+	from := filepath.Join(root, "from")
+	to := filepath.Join(root, "to")
+	if err := os.MkdirAll(from, 0o755); err != nil {
+		t.Fatalf("mkdir from failed: %v", err)
+	}
+	if err := os.MkdirAll(to, 0o755); err != nil {
+		t.Fatalf("mkdir to failed: %v", err)
+	}
+
+	src := filepath.Join(from, "progress.jpg")
+	mustWriteFile(t, src, "progress content")
+	mustSetMtime(t, src, time.Date(2024, 7, 8, 9, 10, 11, 0, time.UTC))
+
+	cfg := importConfig{
+		From:       from,
+		To:         to,
+		Filter:     "jpg",
+		Start:      20240708,
+		End:        20240708,
+		MaxWorkers: 1,
+	}
+
+	var out bytes.Buffer
+	var progress bytes.Buffer
+	summary, err := runImport(cfg, &out, &progress)
+	if err != nil {
+		t.Fatalf("runImport returned error: %v\noutput:\n%s", err, out.String())
+	}
+	if summary.copied != 1 {
+		t.Fatalf("expected copied=1, got: %d", summary.copied)
+	}
+	if strings.Contains(out.String(), "Done checking") {
+		t.Fatalf("expected progress output to stay out of main output, got: %q", out.String())
+	}
+	if !strings.Contains(progress.String(), "Done checking 1/1") {
+		t.Fatalf("expected progress output in dedicated writer, got: %q", progress.String())
 	}
 }

--- a/import_integration_test.go
+++ b/import_integration_test.go
@@ -192,6 +192,9 @@ func TestRunImportWritesProgressToDedicatedWriter(t *testing.T) {
 	if !strings.Contains(progress.String(), "Done checking 1/1") {
 		t.Fatalf("expected progress output in dedicated writer, got: %q", progress.String())
 	}
+	if !strings.Contains(progress.String(), "\033[2K") {
+		t.Fatalf("expected ANSI clearing sequence in progress output, got: %q", progress.String())
+	}
 }
 
 func TestRunImportDoesNotWriteProgressWhenDisabled(t *testing.T) {

--- a/import_integration_test.go
+++ b/import_integration_test.go
@@ -193,3 +193,81 @@ func TestRunImportWritesProgressToDedicatedWriter(t *testing.T) {
 		t.Fatalf("expected progress output in dedicated writer, got: %q", progress.String())
 	}
 }
+
+func TestRunImportDoesNotWriteProgressWhenDisabled(t *testing.T) {
+	root := t.TempDir()
+	from := filepath.Join(root, "from")
+	to := filepath.Join(root, "to")
+	if err := os.MkdirAll(from, 0o755); err != nil {
+		t.Fatalf("mkdir from failed: %v", err)
+	}
+	if err := os.MkdirAll(to, 0o755); err != nil {
+		t.Fatalf("mkdir to failed: %v", err)
+	}
+
+	src := filepath.Join(from, "quiet.jpg")
+	mustWriteFile(t, src, "quiet content")
+	mustSetMtime(t, src, time.Date(2024, 7, 8, 9, 10, 11, 0, time.UTC))
+
+	cfg := importConfig{
+		From:       from,
+		To:         to,
+		Filter:     "jpg",
+		Start:      20240708,
+		End:        20240708,
+		MaxWorkers: 1,
+	}
+
+	var out bytes.Buffer
+	summary, err := runImport(cfg, &out, nil)
+	if err != nil {
+		t.Fatalf("runImport returned error: %v\noutput:\n%s", err, out.String())
+	}
+	if summary.copied != 1 {
+		t.Fatalf("expected copied=1, got: %d", summary.copied)
+	}
+	if strings.Contains(out.String(), "Done checking") {
+		t.Fatalf("expected no progress output in main output when progress is disabled, got: %q", out.String())
+	}
+}
+
+func TestRunImportLeavesProgressWriterEmptyWhenNoFilesMatch(t *testing.T) {
+	root := t.TempDir()
+	from := filepath.Join(root, "from")
+	to := filepath.Join(root, "to")
+	if err := os.MkdirAll(from, 0o755); err != nil {
+		t.Fatalf("mkdir from failed: %v", err)
+	}
+	if err := os.MkdirAll(to, 0o755); err != nil {
+		t.Fatalf("mkdir to failed: %v", err)
+	}
+
+	src := filepath.Join(from, "ignored.txt")
+	mustWriteFile(t, src, "ignored content")
+	mustSetMtime(t, src, time.Date(2024, 7, 8, 9, 10, 11, 0, time.UTC))
+
+	cfg := importConfig{
+		From:       from,
+		To:         to,
+		Filter:     "jpg",
+		Start:      20240708,
+		End:        20240708,
+		MaxWorkers: 1,
+	}
+
+	var out bytes.Buffer
+	var progress bytes.Buffer
+	summary, err := runImport(cfg, &out, &progress)
+	if err != nil {
+		t.Fatalf("runImport returned error: %v\noutput:\n%s", err, out.String())
+	}
+	if summary.processed != 0 || summary.copied != 0 || summary.skipped != 0 || summary.failed != 0 {
+		t.Fatalf("expected empty summary, got: %+v", summary)
+	}
+	if progress.Len() != 0 {
+		t.Fatalf("expected no progress output when no files match, got: %q", progress.String())
+	}
+	if !strings.Contains(out.String(), "Done. processed=0 copied=0 skipped=0 failed=0") {
+		t.Fatalf("expected final summary in main output, got: %q", out.String())
+	}
+}


### PR DESCRIPTION
## Summary
- add a spinner-style progress indicator while files are processed
- show processed/copied/skipped/failed counts and current file name
- send progress updates to stderr to keep stdout clean