### PR TITLE
Improve start and end date flag handling

### DIFF
--- a/import.go
+++ b/import.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -20,8 +19,8 @@ type importConfig struct {
 	From       string
 	To         string
 	Filter     string
-	Start      uint
-	End        uint
+	Start      time.Time
+	End        time.Time
 	MaxWorkers int
 	UseModTime bool
 }
@@ -114,16 +113,33 @@ func findTagInAllIfds(index *exif.IfdIndex, tagName string) (string, error) {
 
 func parseFlags(args []string) (importConfig, error) {
 	var cfg importConfig
+	var startStr, endStr string
 	fs := flag.NewFlagSet("file-importer", flag.ContinueOnError)
 	fs.StringVar(&cfg.From, "from", "", "Source path")
 	fs.StringVar(&cfg.To, "to", "", "Destination path")
 	fs.StringVar(&cfg.Filter, "filter", "", "Optional file type filter")
-	fs.UintVar(&cfg.Start, "start", uint(0), "Start date")
-	fs.UintVar(&cfg.End, "end", ^uint(0), "End date")
+	fs.StringVar(&startStr, "start", "", "Start date (format YYYY-MM-DD)")
+	fs.StringVar(&endStr, "end", "", "End date (format YYYY-MM-DD)")
 	fs.IntVar(&cfg.MaxWorkers, "workers", 10, "Maximum number of concurrent workers")
 	fs.BoolVar(&cfg.UseModTime, "fast", false, "Use filesystem modtime instead of parsing EXIF/CR3 to massively increase speed")
 	if err := fs.Parse(args); err != nil {
 		return importConfig{}, err
+	}
+	if startStr != "" {
+		startDay, err := time.ParseInLocation("2006-01-02", startStr, time.Local)
+		if err != nil {
+			return importConfig{}, fmt.Errorf("invalid start date format (use YYYY-MM-DD): %w", err)
+		}
+		cfg.Start = startDay
+	}
+	if endStr != "" {
+		endDay, err := time.ParseInLocation("2006-01-02", endStr, time.Local)
+		if err != nil {
+			return importConfig{}, fmt.Errorf("invalid end date format (use YYYY-MM-DD): %w", err)
+		}
+		cfg.End = endDay.AddDate(0, 0, 1).Add(-time.Nanosecond)
+	} else {
+		cfg.End = time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
 	}
 	if cfg.From == "" || cfg.To == "" {
 		return importConfig{}, fmt.Errorf("need source and target directory (use '--from' and '--to')")
@@ -265,8 +281,7 @@ func runImport(cfg importConfig, out, progress io.Writer) (importSummary, error)
 				} else {
 					timestamp = resolveTimestamp(filepath.Join(cfg.From, fi.Name()), fi, logf)
 				}
-				i, _ := strconv.Atoi(timestamp.Format("20060102"))
-				if uint(i) < cfg.Start || uint(i) > cfg.End {
+				if timestamp.Before(cfg.Start) || timestamp.After(cfg.End) {
 					mu.Lock()
 					summary.skipped++
 					mu.Unlock()

--- a/import_integration_test.go
+++ b/import_integration_test.go
@@ -32,6 +32,34 @@ func TestParseFlagsRejectsInvalidWorkers(t *testing.T) {
 	}
 }
 
+func TestParseFlagsParsesValidDates(t *testing.T) {
+	cfg, err := parseFlags([]string{"--from", "/src", "--to", "/dst", "--start", "2024-03-03", "--end", "2024-03-31"})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if cfg.Start.Year() != 2024 || cfg.Start.Month() != 3 || cfg.Start.Day() != 3 {
+		t.Fatalf("expected start 2024-03-03, got: %v", cfg.Start)
+	}
+	if cfg.End.Year() != 2024 || cfg.End.Month() != 3 || cfg.End.Day() != 31 {
+		t.Fatalf("expected end 2024-03-31, got: %v", cfg.End)
+	}
+	if cfg.End.Hour() != 23 || cfg.End.Minute() != 59 || cfg.End.Second() != 59 {
+		t.Fatalf("expected end time 23:59:59, got: %v", cfg.End)
+	}
+}
+
+func TestParseFlagsRejectsInvalidStartOrEnd(t *testing.T) {
+	_, err := parseFlags([]string{"--from", "/src", "--to", "/dst", "--start", "invalid"})
+	if err == nil || !strings.Contains(err.Error(), "invalid start date format") {
+		t.Fatalf("expected start date validation error, got: %v", err)
+	}
+
+	_, err = parseFlags([]string{"--from", "/src", "--to", "/dst", "--end", "2024-99-99"})
+	if err == nil || !strings.Contains(err.Error(), "invalid end date format") {
+		t.Fatalf("expected end date validation error, got: %v", err)
+	}
+}
+
 func TestRunImportAppliesFilterAndDateRange(t *testing.T) {
 	root := t.TempDir()
 	from := filepath.Join(root, "from")
@@ -59,8 +87,8 @@ func TestRunImportAppliesFilterAndDateRange(t *testing.T) {
 		From:       from,
 		To:         to,
 		Filter:     "jpg",
-		Start:      20240303,
-		End:        20240331,
+		Start:      time.Date(2024, 3, 3, 0, 0, 0, 0, time.UTC),
+		End:        time.Date(2024, 3, 31, 23, 59, 59, 0, time.UTC),
 		MaxWorkers: 2,
 	}
 
@@ -118,8 +146,8 @@ func TestRunImportNormalizesExtensionFolderName(t *testing.T) {
 		From:       from,
 		To:         to,
 		Filter:     "jpg",
-		Start:      20240708,
-		End:        20240708,
+		Start:      time.Date(2024, 7, 8, 0, 0, 0, 0, time.UTC),
+		End:        time.Date(2024, 7, 8, 23, 59, 59, 0, time.UTC),
 		MaxWorkers: 1,
 	}
 
@@ -172,8 +200,8 @@ func TestRunImportWritesProgressToDedicatedWriter(t *testing.T) {
 		From:       from,
 		To:         to,
 		Filter:     "jpg",
-		Start:      20240708,
-		End:        20240708,
+		Start:      time.Date(2024, 7, 8, 0, 0, 0, 0, time.UTC),
+		End:        time.Date(2024, 7, 8, 23, 59, 59, 0, time.UTC),
 		MaxWorkers: 1,
 	}
 
@@ -216,8 +244,8 @@ func TestRunImportDoesNotWriteProgressWhenDisabled(t *testing.T) {
 		From:       from,
 		To:         to,
 		Filter:     "jpg",
-		Start:      20240708,
-		End:        20240708,
+		Start:      time.Date(2024, 7, 8, 0, 0, 0, 0, time.UTC),
+		End:        time.Date(2024, 7, 8, 23, 59, 59, 0, time.UTC),
 		MaxWorkers: 1,
 	}
 
@@ -253,8 +281,8 @@ func TestRunImportLeavesProgressWriterEmptyWhenNoFilesMatch(t *testing.T) {
 		From:       from,
 		To:         to,
 		Filter:     "jpg",
-		Start:      20240708,
-		End:        20240708,
+		Start:      time.Date(2024, 7, 8, 0, 0, 0, 0, time.UTC),
+		End:        time.Date(2024, 7, 8, 23, 59, 59, 0, time.UTC),
 		MaxWorkers: 1,
 	}
 
@@ -301,8 +329,8 @@ func TestRunImportBypassesExifWithFastFlag(t *testing.T) {
 	cfg := importConfig{
 		From:       from,
 		To:         to,
-		Start:      0,
-		End:        20250101,
+		Start:      time.Time{}, // 0
+		End:        time.Date(2025, 1, 1, 23, 59, 59, 0, time.UTC), // 20250101
 		MaxWorkers: 1,
 	}
 


### PR DESCRIPTION
Migrated the `--start` and `--end` flags from `uint` (YYYYMMDD) to accepted `time.Time` strings in standard `YYYY-MM-DD` format. This makes the tool more idiomatic, robust via early validation, and performs faster comparing times natively instead of doing repetitive integer conversions inside worker threads.